### PR TITLE
fix backtrace

### DIFF
--- a/funl/funl.go
+++ b/funl/funl.go
@@ -154,6 +154,7 @@ func evalAndAssignValuesForSymbolsInFrameForNS(frame *Frame, ns *NSpace) {
 					Syms:     NewSymt(),
 					OtherNS:  make(map[SymID]ImportInfo),
 					Imported: make(map[SymID]*Frame),
+					Previous: frame,
 				}
 				fillSymsForFunc(subframe.Syms, vi.Data.(*Function))
 			}

--- a/std/stdrun.go
+++ b/std/stdrun.go
@@ -39,9 +39,15 @@ func getBacktrace(name string) stdFuncType {
 				break
 			}
 			mapv := funl.HandleMapOP(frame, []*funl.Item{})
-			mapv = putToMap(frame, mapv, "line", funl.Value{Kind: funl.IntValue, Data: prevFrame.FuncProto.Lineno})
-			mapv = putToMap(frame, mapv, "file", funl.Value{Kind: funl.StringValue, Data: prevFrame.FuncProto.SrcFileName})
-			mapv = putToMap(frame, mapv, "args", funl.MakeListOfValues(frame, prevFrame.EvaluatedArgs))
+			if prevFrame.FuncProto == nil {
+				mapv = putToMap(frame, mapv, "line", funl.Value{Kind: funl.IntValue, Data: 0})
+				mapv = putToMap(frame, mapv, "file", funl.Value{Kind: funl.StringValue, Data: "-"})
+				mapv = putToMap(frame, mapv, "args", funl.MakeListOfValues(frame, []funl.Value{}))
+			} else {
+				mapv = putToMap(frame, mapv, "line", funl.Value{Kind: funl.IntValue, Data: prevFrame.FuncProto.Lineno})
+				mapv = putToMap(frame, mapv, "file", funl.Value{Kind: funl.StringValue, Data: prevFrame.FuncProto.SrcFileName})
+				mapv = putToMap(frame, mapv, "args", funl.MakeListOfValues(frame, prevFrame.EvaluatedArgs))
+			}
 
 			stack = append(stack, mapv)
 			prevFrame = prevFrame.Previous


### PR DESCRIPTION
Fixing problem that in case stddbc.assert is used in main namespace level (not in function or procedure) then there's no related file/lineno/arguments information available. In that case default values are printed as frame.
